### PR TITLE
Unreal demo

### DIFF
--- a/cram_knowrob/cram_cloud_logger/src/package.lisp
+++ b/cram_knowrob/cram_cloud_logger/src/package.lisp
@@ -1,3 +1,9 @@
 (defpackage :cram-cloud-logger
   (:nicknames :ccl)
-  (:use :cpl))
+  (:use :cpl)
+  (:export
+   ;; cloud-logger-query-handler
+   #:init-logging
+   #:finish-logging
+   #:start-episode
+   #:stop-episode))

--- a/cram_learning/cram_sim_log_generator/src/main.lisp
+++ b/cram_learning/cram_sim_log_generator/src/main.lisp
@@ -1,3 +1,33 @@
+;;;
+;;; Copyright (c) 2021, Michael Neumann <mine1@uni-bremen.de>
+;;;                     Arthur Niedzwiecki <aniedz@cs.uni-bremen.de>
+;;; All rights reserved.
+;;;
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions are met:
+;;;
+;;;     * Redistributions of source code must retain the above copyright
+;;;       notice, this list of conditions and the following disclaimer.
+;;;     * Redistributions in binary form must reproduce the above copyright
+;;;       notice, this list of conditions and the following disclaimer in the
+;;;       documentation and/or other materials provided with the distribution.
+;;;     * Neither the name of the Institute for Artificial Intelligence/
+;;;       Universitaet Bremen nor the names of its contributors may be used to
+;;;       endorse or promote products derived from this software without
+;;;       specific prior written permission.
+;;;
+;;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+;;; LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+;;; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+;;; SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+;;; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+;;; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+;;; POSSIBILITY OF SUCH DAMAGE.
+
 (in-package :cslg)
 (defparameter *mongo-logger* nil)
 (defparameter num-experiments 1)
@@ -27,57 +57,49 @@
   (when (not ccl::*is-client-connected*)
     (/ 1 0)))
 
-(defun call-reset-world-service (id)
-  "resets the Unreal world"
+(defun call-reset-world-service (&optional (id "0"))
+  (roslisp:ros-info (logging-demo reset-world) "Resetting Unreal world.")
   (if (not (roslisp:wait-for-service "/UnrealSim/reset_level" 10))
       (roslisp:ros-warn (send-reset-world-client) "timed out waiting for send-reset-world service")
-      (roslisp:call-service "/UnrealSim/reset_level" 'world_control_msgs-srv:ResetLevel :id id)))
+      (roslisp:call-service "/UnrealSim/reset_level" 'world_control_msgs-srv:ResetLevel :id id))
+  (sleep 2))
 
-(defun main ()
-  (ros-load:load-system "cram_pr2_process_modules" :cram-pr2-process-modules)
-  (ros-load:load-system "cram_pr2_description" :cram-pr2-description)
-
-  ;;(ros-load:load-system "cram_boxy_description" :cram-boxy-description)
-  ;;(setf cram-bullet-reasoning-belief-state:*spawn-debug-window* nil)
+;; Use like this:
+;; (main)
+;; (main :objects '(:cup :bowl))
+;; (main :logging-enabled T)
+;; (main :objects '(:milk :spoon) :logging-enabled NIL)
+(defun main (&key (objects '(;; :milk
+                             ;; :breakfast-cereal
+                             ;; :spoon
+                             ;; :bowl
+                             :cup
+                             ))
+               (logging-enabled NIL))
+  (unless (eq (roslisp:node-status) :RUNNING)
+    (roslisp-utilities:startup-ros :name "cram" :anonymous nil))
+  (when logging-enabled (prepare-logging))
+  ;; (setf cram-bullet-reasoning-belief-state:*spawn-debug-window* nil)
   ;; (setf cram-tf:*tf-broadcasting-enabled* t)
   ;; (setf cram-urdf-projection-reasoning::*projection-checks-enabled* nil)
-  (roslisp-utilities:startup-ros :name "cram" :anonymous nil)
-
-
-
-  ;;(setq roslisp::*debug-stream* nil)
-  (print "Init bullet world")
+  ;; (setq roslisp::*debug-stream* nil)
+  ;; (pr2-pms:with-real-robot (demo::park-robot))
+  
+  ;; Demo loop
   (dotimes (n 100)
-    (progn (setf ccl::*retry-numbers* 0)
-           (ccl::start-episode)
-           ;; (pr2-pms:with-real-robot (demo::park-robot))
-           (cpl:with-failure-handling
-            ((common-fail:high-level-failure (e)
-                                             (roslisp:ros-warn (pp-plans demo) "Failure happened: ~a~%Skipping..." e)
-                                             (return)))
-           ;; (pr2-pms:with-real-robot (demo::setting-demo '(:spoon))))
-           ;; (pr2-pms:with-real-robot (demo::setting-demo '(:milk))))
-           ;; (pr2-pms:with-real-robot (demo::setting-demo '(:bowl)))
-           ;; (pr2-pms:with-real-robot (demo::setting-demo '(:cup))))
-           ;; (pr2-pms:with-real-robot (demo::setting-demo '(:breakfast-cereal))))
-           ;; (pr2-pms:with-real-robot (demo::setting-demo '(:spoon :bowl :milk))))
-           (pr2-pms:with-real-robot (demo::setting-demo '(:spoon :bowl :milk :breakfast-cereal ))))
-           (setf *main-result* (push ccl::*retry-numbers* *main-result*))
-           (ccl::stop-episode)
-           (call-reset-world-service (write-to-string n))
-           (sleep 2)))
+    (setf ccl::*retry-numbers* 0)
+    (call-reset-world-service)
+    (when logging-enabled (ccl:start-episode))
+    
+    (cpl:with-failure-handling
+        ((common-fail:high-level-failure (e)
+           (roslisp:ros-warn (pp-plans demo) "Failure happened: ~a~%Skipping..." e)
+           (return)))
+      (pr2-pms:with-real-robot (demo::setting-demo objects)))
+
+    (push ccl::*retry-numbers* *main-result*)
+    (when logging-enabled (ccl:stop-episode))
+    (sleep 2))
+  
   (print *main-result*)
-  ;;      do (progn
-  ;;           (print "Start")
-             ;; (ccl::start-episode)
-             ;;(urdf-proj:with-simulated-robot (demo::demo-random nil ))
-             ;; ;; (pr2-pms:with-real-robot (demo::setting-demo '(:breakfast-cereal :bowl :spoon :cup :milk)))
-  ;;           (pr2-pms:with-real-robot (demo::setting-demo '(:milk)))
-             ;; (pr2-pms:with-real-robot (demo::setting-demo '(:breakfast-cereal :milk )))
-             ;; (pr2-pms:with-real-robot (demo::setting-demo '(:bowl :spoon :cup :breakfast-cereal :milk)))
-             ;; (pr2-pms:with-real-robot (demo::setting-demo '(:milk :breakfast-cereal :bowl :spoon :cup)))
-             ;; (pr2-pms:with-real-robot (demo::setting-demo '(:bowl :spoon :cup )))
-             ;; (ccl::stop-episode)
-  ;;           (print "End")))
-  (ccl::finish-logging)
-  )
+  (when logging-enabled (ccl:finish-logging)))

--- a/cram_pr2/cram_pr2_low_level/src/gripper.lisp
+++ b/cram_pr2/cram_pr2_low_level/src/gripper.lisp
@@ -116,6 +116,10 @@
                                     convergence-delta)
   (when (eql status :timeout)
     (roslisp:ros-warn (pr2-ll gripper) "Gripper action timed out."))
+  (when (eql status :lost)
+    (cpl:fail 'common-fail:gripper-goal-not-reached
+              :description (format nil "Gripper action lost, probably due to wiggeling:
+result: ~a, goal: ~a, delta: ~a." result goal-position convergence-delta)))
   (let* ((current-position
            (pr2_controllers_msgs-msg:position result))
          ;; TODO: use current-position from joint state message, not result


### PR DESCRIPTION
* exports logging functions to use in the logging demo
* throw failure when the gripper goal is lost due to wiggling (failure is caught at a higher level to retry)
* cleanup demo
  * basically does the same as before, but with less code
  * optionally toggle logging
  * set default objects to apply demo on