### PR TITLE
Unreal demo

### DIFF
--- a/cram_external_interfaces/cram_urobosim/CMakeLists.txt
+++ b/cram_external_interfaces/cram_urobosim/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(cram_urobosim)
+find_package(catkin REQUIRED)
+catkin_package()
+

--- a/cram_external_interfaces/cram_urobosim/cram-urobosim.asd
+++ b/cram_external_interfaces/cram_urobosim/cram-urobosim.asd
@@ -1,0 +1,56 @@
+;;; Copyright (c) 2019, Gayane Kazhoyan <kazhoyan@cs.uni-bremen.de>
+;;; All rights reserved.
+;;;
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions are met:
+;;;
+;;;     * Redistributions of source code must retain the above copyright
+;;;       notice, this list of conditions and the following disclaimer.
+;;;     * Redistributions in binary form must reproduce the above copyright
+;;;       notice, this list of conditions and the following disclaimer in the
+;;;       documentation and/or other materials provided with the distribution.
+;;;     * Neither the name of the Intelligent Autonomous Systems Group/
+;;;       Technische Universitaet Muenchen nor the names of its contributors
+;;;       may be used to endorse or promote products derived from this software
+;;;       without specific prior written permission.
+;;;
+;;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+;;; LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+;;; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+;;; SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+;;; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+;;; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+;;; POSSIBILITY OF SUCH DAMAGE.
+
+(defsystem cram-urobosim
+  :author "Gayane Kazhoyan"
+  :maintainer "Gayane Kazhoyan"
+  :license "BSD"
+
+  :depends-on (cram-simple-actionlib-client
+               roslisp
+               roslisp-utilities
+               urobosim_msgs-msg
+               cl-transforms-stamped
+               cram-designators
+               cram-tf
+               cram-common-failures
+               cram-prolog
+               cram-bullet-reasoning
+               cram-utilities
+               cram-pr2-description
+               cram-process-modules
+               cram-common-designators)
+  :components
+  ((:module "src"
+    :components
+    ((:file "package")
+     (:file "action-client" :depends-on ("package"))
+     (:file "low-level" :depends-on ("package" "action-client"))
+     (:file "feeding-plans" :depends-on ("package"))
+     (:file "feeding-designators" :depends-on ("package" "feeding-plans"))
+     (:file "process-module" :depends-on ("package" "low-level"))))))

--- a/cram_external_interfaces/cram_urobosim/package.xml
+++ b/cram_external_interfaces/cram_urobosim/package.xml
@@ -1,0 +1,27 @@
+<package format="2">
+  <name>cram_urobosim</name>
+  <version>0.1.0</version>
+  <description>
+    CRAM interfaces to talk to Unreal Simulator
+  </description>
+  <author>Gayane Kazhoyan</author>
+  <maintainer email="kazhoyan@cs.uni-bremen.de">Gayane Kazhoyan</maintainer>
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <depend>cram_simple_actionlib_client</depend>
+  <depend>roslisp</depend>
+  <depend>roslisp_utilities</depend>
+  <depend>urobosim_msgs</depend>
+  <depend>cl_transforms_stamped</depend>
+  <depend>cram_designators</depend>
+  <depend>cram_tf</depend>
+  <depend>cram_common_failures</depend>
+  <depend>cram_prolog</depend>
+  <depend>cram_bullet_reasoning</depend>
+  <depend>cram_utilities</depend>
+  <depend>cram_pr2_description</depend>
+  <depend>cram_process_modules</depend>
+  <depend>cram_common_designators</depend>
+</package>

--- a/cram_external_interfaces/cram_urobosim/src/action-client.lisp
+++ b/cram_external_interfaces/cram_urobosim/src/action-client.lisp
@@ -1,0 +1,74 @@
+;;;
+;;; Copyright (c) 2019, Gayane Kazhoyan <kazhoyan@cs.uni-bremen.de>
+;;; All rights reserved.
+;;;
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions are met:
+;;;
+;;;     * Redistributions of source code must retain the above copyright
+;;;       notice, this list of conditions and the following disclaimer.
+;;;     * Redistributions in binary form must reproduce the above copyright
+;;;       notice, this list of conditions and the following disclaimer in the
+;;;       documentation and/or other materials provided with the distribution.
+;;;     * Neither the name of the Institute for Artificial Intelligence/
+;;;       Universitaet Bremen nor the names of its contributors may be used to
+;;;       endorse or promote products derived from this software without
+;;;       specific prior written permission.
+;;;
+;;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+;;; LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+;;; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+;;; SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+;;; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+;;; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+;;; POSSIBILITY OF SUCH DAMAGE.
+
+(in-package :unreal)
+
+(defparameter *perceive-action-timeout* 3.0
+  "How many seconds to wait before returning from perceive action.")
+
+(defun make-urobosim-action-client ()
+  (actionlib-client:make-simple-action-client
+   'urobosim-action
+   "perceive_object"
+   "urobosim_msgs/PerceiveObjectAction"
+   *perceive-action-timeout*))
+
+(roslisp-utilities:register-ros-init-function make-urobosim-action-client)
+
+(defun ensure-input-params (object-type)
+  (declare (type (or string symbol) object-type))
+  (when (symbolp object-type)
+    (setf object-type (symbol-name object-type))))
+
+(defun ensure-output-params (name-pose-pose-world-type-list)
+  (destructuring-bind (name pose pose-world type)
+      name-pose-pose-world-type-list
+    (list (intern name :keyword) pose pose-world type)))
+
+(defun make-perceive-action-goal (object-type)
+  (declare (type string object-type))
+  (roslisp:make-msg
+   'urobosim_msgs-msg:PerceiveObjectGoal
+   :type object-type))
+
+(defun call-perceive-action (&key object-type (action-timeout *perceive-action-timeout*))
+  "Returns the following list: (output-name output-pose-in-map input-object-type)"
+  (multiple-value-bind (result status)
+      (actionlib-client:call-simple-action-client
+       'urobosim-action
+       :action-goal (make-perceive-action-goal (ensure-input-params object-type))
+       :action-timeout action-timeout)
+    (roslisp:ros-info (perceive-action) "perceive action finished.")
+    (when (eq status :succeeded)
+      (roslisp:with-fields ((name urobosim_msgs-msg:name)
+                            (pose-in-map urobosim_msgs-msg:pose_world)
+                            (pose-in-base urobosim_msgs-msg:pose))
+          result
+        (ensure-output-params
+         (list name (cl-transforms-stamped:from-msg pose-in-base) (cl-transforms-stamped:from-msg pose-in-map) object-type))))))

--- a/cram_external_interfaces/cram_urobosim/src/feeding-designators.lisp
+++ b/cram_external_interfaces/cram_urobosim/src/feeding-designators.lisp
@@ -1,0 +1,42 @@
+;;;
+;;; Copyright (c) 2019, Gayane Kazhoyan <kazhoyan@cs.uni-bremen.de>
+;;; All rights reserved.
+;;;
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions are met:
+;;;
+;;;     * Redistributions of source code must retain the above copyright
+;;;       notice, this list of conditions and the following disclaimer.
+;;;     * Redistributions in binary form must reproduce the above copyright
+;;;       notice, this list of conditions and the following disclaimer in the
+;;;       documentation and/or other materials provided with the distribution.
+;;;     * Neither the name of the Institute for Artificial Intelligence/
+;;;       Universitaet Bremen nor the names of its contributors may be used to
+;;;       endorse or promote products derived from this software without
+;;;       specific prior written permission.
+;;;
+;;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+;;; LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+;;; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+;;; SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+;;; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+;;; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+;;; POSSIBILITY OF SUCH DAMAGE.
+
+(in-package :unreal)
+
+(def-fact-group feeding-designators (desig:action-grounding)
+  (<- (desig:action-grounding ?action-designator (spooning
+                                                  ?fetching-location-designator
+                                                  ?delivering-location-designator
+                                                  ))
+    (spec:property ?action-designator (:type :spooning))
+    (spec:property ?action-designator (:location ?some-fetching-location-designator))
+    (desig:current-designator ?some-fetching-location-designator ?fetching-location-designator)
+    (spec:property ?action-designator (:target ?some-delivering-location-designator))
+    (desig:current-designator ?some-delivering-location-designator ?delivering-location-designator)
+    ))

--- a/cram_external_interfaces/cram_urobosim/src/feeding-plans.lisp
+++ b/cram_external_interfaces/cram_urobosim/src/feeding-plans.lisp
@@ -1,0 +1,86 @@
+;;;
+;;; Copyright (c) 2019, Gayane Kazhoyan <kazhoyan@cs.uni-bremen.de>
+;;; All rights reserved.
+;;;
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions are met:
+;;;
+;;;     * Redistributions of source code must retain the above copyright
+;;;       notice, this list of conditions and the following disclaimer.
+;;;     * Redistributions in binary form must reproduce the above copyright
+;;;       notice, this list of conditions and the following disclaimer in the
+;;;       documentation and/or other materials provided with the distribution.
+;;;     * Neither the name of the Institute for Artificial Intelligence/
+;;;       Universitaet Bremen nor the names of its contributors may be used to
+;;;       endorse or promote products derived from this software without
+;;;       specific prior written permission.
+;;;
+;;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+;;; LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+;;; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+;;; SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+;;; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+;;; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+;;; POSSIBILITY OF SUCH DAMAGE.
+
+(in-package :unreal)
+
+;; (cpl:def-cram-function spooning (?fetching-location
+;;                                  ?delivering-location)
+;;    (exe:perform
+;;     (let ((?pose (cl-tf:make-pose-stamped
+;;                   cram-tf:*robot-base-frame* 0.0
+;;                   (cl-transforms:make-3d-vector 0.65 0.25 1.13)
+;;                   (cl-transforms:euler->quaternion :az 1.9 :ay (/ (* pi 1) 4)))))
+;;    (desig:a motion (type moving-tcp) (left-pose ?pose))))
+
+;;    (exe:perform
+;;     (let ((?pose (cl-tf:make-pose-stamped
+;;                   cram-tf:*robot-base-frame* 0.0
+;;                   (cl-transforms:make-3d-vector 0.63 0.16 1.03)
+;;                   (cl-transforms:euler->quaternion :az 1.9 :ay (/ (* pi 1) 4)))))
+;;    (desig:a motion (type moving-tcp) (left-pose ?pose))))
+
+;;    (exe:perform
+;;     (let ((?pose (cl-tf:make-pose-stamped
+;;                   cram-tf:*robot-base-frame* 0.0
+;;                   (cl-transforms:make-3d-vector 0.63 0.13 0.96)
+;;                   ;; (cl-transforms:euler->quaternion :az (/ pi 2) :ay (/ pi -4)))))
+;;                   ;; (cl-transforms:euler->quaternion :az (/ pi 2) :ay (/ (* pi 1) 4)))))
+;;                   (cl-transforms:euler->quaternion :az 1.9 :ay (/ (* pi 1) 4)))))
+;;       (desig:a motion (type moving-tcp) (left-pose ?pose))))
+
+;;    (exe:perform
+;;     (let ((?pose (cl-tf:make-pose-stamped
+;;                   cram-tf:*robot-base-frame* 0.0
+;;                   (cl-transforms:make-3d-vector 0.63 0.15 0.98)
+;;                   (cl-transforms:euler->quaternion :az (/ pi 2) :ay (/  pi  2)))))
+;;    (desig:a motion (type moving-tcp) (left-pose ?pose))))
+
+;;    (exe:perform
+;;     (let ((?pose (cl-tf:make-pose-stamped
+;;                   cram-tf:*robot-base-frame* 0.0
+;;                   (cl-transforms:make-3d-vector 0.65 0.1 1.0)
+;;                   (cl-transforms:euler->quaternion :az (/ pi 2) :ay (/  pi  2)))))
+;;    (desig:a motion (type moving-tcp) (left-pose ?pose))))
+
+
+;;    (exe:perform
+;;     (let ((?pose (cl-tf:make-pose-stamped
+;;                   cram-tf:*robot-base-frame* 0.0
+;;                   (cl-transforms:make-3d-vector 0.6 0.4 1.11)
+;;                   (cl-transforms:euler->quaternion :az 3.9 :ay (/  pi  2)))))
+;;    (desig:a motion (type moving-tcp) (left-pose ?pose))))
+
+;;    (exe:perform
+;;     (let ((?pose (cl-tf:make-pose-stamped
+;;                   cram-tf:*robot-base-frame* 0.0
+;;                   (cl-transforms:make-3d-vector 0.6 0.6 1.15)
+;;                   (cl-transforms:euler->quaternion :az 4.0 :ay (/  pi  2)))))
+;;    (desig:a motion (type moving-tcp) (left-pose ?pose))))
+
+;;                     )

--- a/cram_external_interfaces/cram_urobosim/src/low-level.lisp
+++ b/cram_external_interfaces/cram_urobosim/src/low-level.lisp
@@ -1,0 +1,123 @@
+;;;
+;;; Copyright (c) 2019, Gayane Kazhoyan <kazhoyan@cs.uni-bremen.de>
+;;; All rights reserved.
+;;;
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions are met:
+;;;
+;;;     * Redistributions of source code must retain the above copyright
+;;;       notice, this list of conditions and the following disclaimer.
+;;;     * Redistributions in binary form must reproduce the above copyright
+;;;       notice, this list of conditions and the following disclaimer in the
+;;;       documentation and/or other materials provided with the distribution.
+;;;     * Neither the name of the Institute for Artificial Intelligence/
+;;;       Universitaet Bremen nor the names of its contributors may be used to
+;;;       endorse or promote products derived from this software without
+;;;       specific prior written permission.
+;;;
+;;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+;;; LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+;;; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+;;; SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+;;; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+;;; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+;;; POSSIBILITY OF SUCH DAMAGE.
+
+(in-package :unreal)
+
+(defun robot-transform-in-map ()
+  (let ((pose-in-map
+          (cl-transforms:make-identity-pose)
+          ;; TODO! Implement correct robot pose in map function
+          ))
+    (cram-tf:pose->transform-stamped
+     cram-tf:*fixed-frame*
+     cram-tf:*robot-base-frame*
+     (cut:current-timestamp)
+     pose-in-map)))
+
+(defun extend-perceived-object-designator (input-designator name-pose-pose-world-type-list)
+  (destructuring-bind (name pose pose-world type) name-pose-pose-world-type-list
+    (let* ((pose-stamped-in-fixed-frame
+             (cl-transforms-stamped:make-pose-stamped
+              cram-tf:*fixed-frame*
+              (cut:current-timestamp)
+              (cl-transforms:origin pose-world)
+              (cl-transforms:orientation pose-world)))
+           (transform-stamped-in-fixed-frame
+             (cram-tf:pose-stamped->transform-stamped
+              pose-stamped-in-fixed-frame
+              (roslisp-utilities:rosify-underscores-lisp-name name)))
+           (pose-stamped-in-base-frame
+             (cl-transforms-stamped:make-pose-stamped
+              cram-tf:*robot-base-frame*
+              (cut:current-timestamp)
+              (cl-transforms:origin pose)
+              (cl-transforms:orientation pose)))
+           (transform-stamped-in-base-frame
+             (cram-tf:pose-stamped->transform-stamped
+              pose-stamped-in-base-frame
+              (roslisp-utilities:rosify-underscores-lisp-name name)))
+           ; (pose-stamped-in-base-frame
+           ;   (cram-tf:multiply-transform-stampeds
+           ;    cram-tf:*robot-base-frame*
+           ;    (roslisp-utilities:rosify-underscores-lisp-name name)
+           ;    (cram-tf:transform-stamped-inv (robot-transform-in-map))
+           ;    transform-stamped-in-fixed-frame
+           ;    :result-as-pose-or-transform :pose))
+           ; (transform-stamped-in-base-frame
+           ;   (cram-tf:multiply-transform-stampeds
+           ;    cram-tf:*robot-base-frame*
+           ;    (roslisp-utilities:rosify-underscores-lisp-name name)
+           ;    (cram-tf:transform-stamped-inv (robot-transform-in-map))
+           ;    transform-stamped-in-fixed-frame
+           ;    :result-as-pose-or-transform :transform))
+           )
+      (let ((output-designator
+              (desig:copy-designator
+               input-designator
+               :new-description
+               `((:type ,type)
+                 (:name ,name)
+                 (:pose ((:pose ,pose-stamped-in-base-frame)
+                         (:transform ,transform-stamped-in-base-frame)
+                         (:pose-in-map ,pose-stamped-in-fixed-frame)
+                         (:transform-in-map ,transform-stamped-in-fixed-frame)))))))
+        (setf (slot-value output-designator 'desig:data)
+              (make-instance 'desig:object-designator-data
+                :object-identifier name
+                :pose pose-stamped-in-fixed-frame
+                :color '(0.5 0.5 0.5)))
+        ;; (desig:equate input-designator output-designator)
+        output-designator))))
+
+(defun detect (input-designator)
+  (declare (type desig:object-designator input-designator))
+
+  (let* ((object-type (desig:desig-prop-value input-designator :type))
+         (quantifier (desig:quantifier input-designator))
+
+         ;; call ros action
+         (name-pose-type-lists (list (call-perceive-action :object-type object-type))))
+
+    ;; check if objects were found
+    (unless (car name-pose-type-lists)
+      (cpl:fail 'common-fail:perception-object-not-found :object input-designator
+                :description (format nil "Could not find object ~a." input-designator)))
+
+    ;; Extend the input-designator with the information found through visibility check:
+    ;; name & pose & type of the object,
+    ;; equate the input-designator to the new output-designator.
+    ;; If multiple objects are visible, return multiple equated objects,
+    ;; otherwise only take first found object. I.e. need to find :an object (not :all objects)
+    (case quantifier
+      (:all (mapcar (alexandria:curry #'extend-perceived-object-designator input-designator)
+                    name-pose-type-lists))
+      ((:a :an) (extend-perceived-object-designator
+                 input-designator
+                 (first name-pose-type-lists)))
+      (t (error "[PROJECTION DETECT]: Quantifier can only be a/an or all.")))))

--- a/cram_external_interfaces/cram_urobosim/src/package.lisp
+++ b/cram_external_interfaces/cram_urobosim/src/package.lisp
@@ -1,0 +1,42 @@
+;;;
+;;; Copyright (c) 2019, Gayane Kazhoyan <kazhoyan@cs.uni-bremen.de>
+;;; All rights reserved.
+;;;
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions are met:
+;;;
+;;;     * Redistributions of source code must retain the above copyright
+;;;       notice, this list of conditions and the following disclaimer.
+;;;     * Redistributions in binary form must reproduce the above copyright
+;;;       notice, this list of conditions and the following disclaimer in the
+;;;       documentation and/or other materials provided with the distribution.
+;;;     * Neither the name of the Institute for Artificial Intelligence/
+;;;       Universitaet Bremen nor the names of its contributors may be used to
+;;;       endorse or promote products derived from this software without
+;;;       specific prior written permission.
+;;;
+;;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+;;; LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+;;; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+;;; SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+;;; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+;;; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+;;; POSSIBILITY OF SUCH DAMAGE.
+
+(in-package :cl-user)
+
+(defpackage cram-urobosim
+  (:nicknames #:unreal)
+  (:use #:common-lisp #:cram-prolog)
+  (:export
+   ;; action-client
+   #:call-perceive-action
+   ;; low-level
+   #:detect
+   #:perceive
+   ;; process-module
+   #:urobosim-perception-pm))

--- a/cram_external_interfaces/cram_urobosim/src/process-module.lisp
+++ b/cram_external_interfaces/cram_urobosim/src/process-module.lisp
@@ -1,0 +1,46 @@
+;;;
+;;; Copyright (c) 2019, Gayane Kazhoyan <kazhoyan@cs.uni-bremen.de>
+;;; All rights reserved.
+;;;
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions are met:
+;;;
+;;;     * Redistributions of source code must retain the above copyright
+;;;       notice, this list of conditions and the following disclaimer.
+;;;     * Redistributions in binary form must reproduce the above copyright
+;;;       notice, this list of conditions and the following disclaimer in the
+;;;       documentation and/or other materials provided with the distribution.
+;;;     * Neither the name of the Institute for Artificial Intelligence/
+;;;       Universitaet Bremen nor the names of its contributors may be used to
+;;;       endorse or promote products derived from this software without
+;;;       specific prior written permission.
+;;;
+;;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+;;; LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+;;; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+;;; SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+;;; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+;;; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+;;; POSSIBILITY OF SUCH DAMAGE.
+
+(in-package :unreal)
+
+(cpm:def-process-module urobosim-perception-pm (motion-designator)
+  (destructuring-bind (command argument-1) (desig:reference motion-designator)
+    (ecase command
+      (cram-common-designators:detect
+       (handler-case
+           (detect argument-1))))))
+
+(prolog:def-fact-group urobosim-pm (cpm:matching-process-module
+                                    cpm:available-process-module)
+
+  (prolog:<- (cpm:matching-process-module ?motion-designator urobosim-perception-pm)
+    (desig:desig-prop ?motion-designator (:type :detecting)))
+
+  (prolog:<- (cpm:available-process-module urobosim-perception-pm)
+    (prolog:not (cpm:projection-running ?_))))

--- a/cram_learning/cram_sim_log_generator/cram-sim-log-generator.asd
+++ b/cram_learning/cram_sim_log_generator/cram-sim-log-generator.asd
@@ -1,3 +1,33 @@
+;;;
+;;; Copyright (c) 2021, Michael Neumann <mine1@uni-bremen.de>
+;;;                     Arthur Niedzwiecki <aniedz@cs.uni-bremen.de>
+;;; All rights reserved.
+;;;
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions are met:
+;;;
+;;;     * Redistributions of source code must retain the above copyright
+;;;       notice, this list of conditions and the following disclaimer.
+;;;     * Redistributions in binary form must reproduce the above copyright
+;;;       notice, this list of conditions and the following disclaimer in the
+;;;       documentation and/or other materials provided with the distribution.
+;;;     * Neither the name of the Institute for Artificial Intelligence/
+;;;       Universitaet Bremen nor the names of its contributors may be used to
+;;;       endorse or promote products derived from this software without
+;;;       specific prior written permission.
+;;;
+;;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+;;; LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+;;; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+;;; SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+;;; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+;;; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+;;; POSSIBILITY OF SUCH DAMAGE.
+
 (defsystem cram-sim-log-generator
   :depends-on (:cram-language
                :cram-designators

--- a/cram_learning/cram_sim_log_generator/src/neem-generator.lisp
+++ b/cram_learning/cram_sim_log_generator/src/neem-generator.lisp
@@ -1,3 +1,33 @@
+;;;
+;;; Copyright (c) 2021, Michael Neumann <mine1@uni-bremen.de>
+;;;                     Arthur Niedzwiecki <aniedz@cs.uni-bremen.de>
+;;; All rights reserved.
+;;;
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions are met:
+;;;
+;;;     * Redistributions of source code must retain the above copyright
+;;;       notice, this list of conditions and the following disclaimer.
+;;;     * Redistributions in binary form must reproduce the above copyright
+;;;       notice, this list of conditions and the following disclaimer in the
+;;;       documentation and/or other materials provided with the distribution.
+;;;     * Neither the name of the Institute for Artificial Intelligence/
+;;;       Universitaet Bremen nor the names of its contributors may be used to
+;;;       endorse or promote products derived from this software without
+;;;       specific prior written permission.
+;;;
+;;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+;;; LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+;;; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+;;; SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+;;; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+;;; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+;;; POSSIBILITY OF SUCH DAMAGE.
+
 (in-package :cslg)
 
 (defun generate-neem (&optional objects-to-fetch-deliever)

--- a/cram_learning/cram_sim_log_generator/src/package.lisp
+++ b/cram_learning/cram_sim_log_generator/src/package.lisp
@@ -1,3 +1,33 @@
+;;;
+;;; Copyright (c) 2021, Michael Neumann <mine1@uni-bremen.de>
+;;;                     Arthur Niedzwiecki <aniedz@cs.uni-bremen.de>
+;;; All rights reserved.
+;;;
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions are met:
+;;;
+;;;     * Redistributions of source code must retain the above copyright
+;;;       notice, this list of conditions and the following disclaimer.
+;;;     * Redistributions in binary form must reproduce the above copyright
+;;;       notice, this list of conditions and the following disclaimer in the
+;;;       documentation and/or other materials provided with the distribution.
+;;;     * Neither the name of the Institute for Artificial Intelligence/
+;;;       Universitaet Bremen nor the names of its contributors may be used to
+;;;       endorse or promote products derived from this software without
+;;;       specific prior written permission.
+;;;
+;;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+;;; LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+;;; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+;;; SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+;;; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+;;; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+;;; POSSIBILITY OF SUCH DAMAGE.
+
 (defpackage :cram-sim-log-generator
   (:nicknames :cslg)
   (:use :cpl))


### PR DESCRIPTION
Transfers the `cram_urobosim` repo into `cram_external_interfaces`
Catkin workspace needs to be cleaned and rebuilt after this PR, because the path to `cram_urobosim` should be directed to the new location within cram's external interfaces.

Also, add some license notes